### PR TITLE
exit 코드 변경

### DIFF
--- a/.github/workflows/dev_cd.yml
+++ b/.github/workflows/dev_cd.yml
@@ -32,7 +32,7 @@ jobs:
         
         if [ "$FULL_NAME" != "$MAIN_REPO" ]; then
           echo "CD is not needed. It will be canceled soon."
-          exit 0
+          exit 78
         else
           echo "CD is needed. It will be continued soon."
         fi


### PR DESCRIPTION
exit 코드를 0에서 78로 변경
  - 78일 경우 해당 작업 이후에 있는 모든 코드를 실행하지 않고 에러처리 없이 종료