### PR TITLE
fix: 게시글 이미지 및 첨부파일 분리

### DIFF
--- a/src/main/java/com/dku/council/domain/post/model/dto/PostFileDto.java
+++ b/src/main/java/com/dku/council/domain/post/model/dto/PostFileDto.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import org.springframework.http.MediaType;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -35,7 +36,14 @@ public class PostFileDto {
     }
 
     public static List<PostFileDto> listOf(ObjectUploadContext context, List<PostFile> entities) {
-        return entities.stream()
+        List<PostFile> result = new ArrayList<>();
+
+        for (PostFile entity : entities) {
+            if (entity.getThumbnailId() == null) {
+                result.add(entity);
+            }
+        }
+        return result.stream()
                 .map(file -> new PostFileDto(context, file))
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/dku/council/domain/post/model/dto/PostImageDto.java
+++ b/src/main/java/com/dku/council/domain/post/model/dto/PostImageDto.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import org.springframework.http.MediaType;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -31,7 +32,7 @@ public class PostImageDto {
 
     public PostImageDto(ObjectUploadContext context, PostFile file) {
         this.id = file.getId();
-        this.url = context.getObjectUrl(file.getFileId());
+        this.url = context.getImageUrl(file.getFileId());
         this.thumbnailUrl = context.getThumbnailUrl(file.getThumbnailId());
         this.originalName = file.getFileName();
 
@@ -40,7 +41,14 @@ public class PostImageDto {
     }
 
     public static List<PostImageDto> listOf(ObjectUploadContext context, List<PostFile> entities) {
-        return entities.stream()
+        List<PostFile> result = new ArrayList<>();
+
+        for (PostFile entity : entities) {
+            if (entity.getThumbnailId() != null) {
+                result.add(entity);
+            }
+        }
+        return result.stream()
                 .map(file -> new PostImageDto(context, file))
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 사항
1. 게시글에 올리는 이미지와 첨부파일 경로를 Post.getFiles() 했을 때 구분하여 출력