### PR TITLE
fix: BusStation 캐싱 시 정류장 이름 입력 없이 모든 데이터 가져오도록 수정

### DIFF
--- a/src/main/java/com/dku/council/domain/bus/controller/BusController.java
+++ b/src/main/java/com/dku/council/domain/bus/controller/BusController.java
@@ -25,15 +25,10 @@ public class BusController {
      * 예상 버스 도착 시간을 조회합니다.
      * 캐싱이 적용됩니다. 데이터는 최신이 아닐 수 있으며, 데이터 가져온 시점은 capturedAt을 통해 알 수 있습니다.
      *
-     * @param stationName 버스 정류장 이름. 가능한 값: 단국대정문, 곰상
      * @return 버스 도착 예상 시간 목록
      */
     @GetMapping
-    public ResponseBusArrivalDto listBusArrivalTime(@NotBlank @RequestParam String stationName) {
-        BusStation station = BusStation.of(stationName);
-        if (station == null) {
-            throw new InvalidBusStationException();
-        }
-        return service.listBusArrival(station);
+    public ResponseBusArrivalDto listBusArrivalTime() {
+        return service.listBusArrival();
     }
 }

--- a/src/main/java/com/dku/council/domain/bus/model/BusStation.java
+++ b/src/main/java/com/dku/council/domain/bus/model/BusStation.java
@@ -4,6 +4,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.util.List;
 import java.util.Set;
 
 @Getter
@@ -35,5 +36,9 @@ public enum BusStation {
             }
         }
         return null;
+    }
+
+    public static List<BusStation> getBusStations() {
+        return List.of(BusStation.values());
     }
 }

--- a/src/main/java/com/dku/council/domain/bus/model/dto/ResponseBusArrivalDto.java
+++ b/src/main/java/com/dku/council/domain/bus/model/dto/ResponseBusArrivalDto.java
@@ -17,5 +17,6 @@ public class ResponseBusArrivalDto {
     @Schema(description = "도착 시간이 계산된 시각", example = "2022-03-01 11:31:11")
     @JsonFormat(pattern = DATE_TIME_FORMAT_PATTERN, timezone = "Asia/Seoul")
     private final Instant capturedAt;
-    private final List<BusArrivalDto> busArrivalList;
+    private final List<BusArrivalDto> busArrivalEntranceList;
+    private final List<BusArrivalDto> busArrivalPlazaList;
 }

--- a/src/test/java/com/dku/council/domain/bus/service/BusServiceTest.java
+++ b/src/test/java/com/dku/council/domain/bus/service/BusServiceTest.java
@@ -55,12 +55,12 @@ class BusServiceTest {
         when(memoryRepository.cacheArrivals(eq(station.name()), any(), any())).thenReturn(cached);
 
         // when
-        ResponseBusArrivalDto dto = service.listBusArrival(BusStation.DKU_GATE);
+        ResponseBusArrivalDto dto = service.listBusArrival();
 
         // then
         verify(openApiBusService).retrieveBusArrival(station);
         assertThat(dto.getCapturedAt().getEpochSecond()).isEqualTo(now.getEpochSecond());
-        assertThat(dto.getBusArrivalList().size()).isEqualTo(5);
+        assertThat(dto.getBusArrivalEntranceList().size()).isEqualTo(5);
     }
 
     @Test
@@ -74,11 +74,11 @@ class BusServiceTest {
         when(memoryRepository.getArrivals(station.name(), now)).thenReturn(Optional.of(cached));
 
         // when
-        ResponseBusArrivalDto dto = service.listBusArrival(BusStation.DKU_GATE);
+        ResponseBusArrivalDto dto = service.listBusArrival();
 
         // then
         assertThat(dto.getCapturedAt().getEpochSecond()).isEqualTo(now.getEpochSecond());
-        assertThat(dto.getBusArrivalList().size()).isEqualTo(5);
+        assertThat(dto.getBusArrivalEntranceList().size()).isEqualTo(5);
     }
 
     @Test
@@ -95,14 +95,14 @@ class BusServiceTest {
         when(memoryRepository.getArrivals(station.name(), now)).thenReturn(Optional.of(cached));
 
         // when
-        ResponseBusArrivalDto dto = service.listBusArrival(BusStation.DKU_GATE);
+        ResponseBusArrivalDto dto = service.listBusArrival();
 
         // then
         assertThat(dto.getCapturedAt().getEpochSecond()).isEqualTo(now.getEpochSecond() - 10);
-        assertThat(dto.getBusArrivalList().size()).isEqualTo(2);
-        assertThat(dto.getBusArrivalList().get(0).getPredictTime1()).isEqualTo(arrivals.get(0).getPredictTimeSec1() - 10);
-        assertThat(dto.getBusArrivalList().get(0).getPredictTime2()).isEqualTo(arrivals.get(0).getPredictTimeSec2() - 10);
-        assertThat(dto.getBusArrivalList().get(1).getPredictTime1()).isEqualTo(0);
-        assertThat(dto.getBusArrivalList().get(1).getPredictTime2()).isEqualTo(0);
+        assertThat(dto.getBusArrivalEntranceList().size()).isEqualTo(2);
+        assertThat(dto.getBusArrivalEntranceList().get(0).getPredictTime1()).isEqualTo(arrivals.get(0).getPredictTimeSec1() - 10);
+        assertThat(dto.getBusArrivalEntranceList().get(0).getPredictTime2()).isEqualTo(arrivals.get(0).getPredictTimeSec2() - 10);
+        assertThat(dto.getBusArrivalEntranceList().get(1).getPredictTime1()).isEqualTo(0);
+        assertThat(dto.getBusArrivalEntranceList().get(1).getPredictTime2()).isEqualTo(0);
     }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 사항
1. BusStation에서 조회 API 사용 시 입력 값 없이 모든 리스트로 가져올수 있도록 수정
