### PR TITLE
fix : 라인업 공개 여부 변경을 축제 일차별로 수정할 수 있도록 변경

### DIFF
--- a/src/main/java/com/dku/council/domain/danfesta/controller/LineUpController.java
+++ b/src/main/java/com/dku/council/domain/danfesta/controller/LineUpController.java
@@ -53,13 +53,13 @@ public class LineUpController {
     }
 
     /**
-     * 라인업 공개 상태로 변경
+     * 일차별 라인업 공개 상태로 변경
      *
      * <p>공개 상태 변경은 boolean타입의 isOpened 값을 false 에서 true로 바꿔줍니다.</p>
      */
     @PatchMapping
     @AdminAuth
-    public void changeToTrue(AppAuthentication auth) {
-        lineUpService.changeToTrue(auth.getUserId());
+    public void changeToTrue(AppAuthentication auth, @RequestParam FestivalDate festivalDate) {
+        lineUpService.changeToTrue(auth.getUserId(), festivalDate);
     }
 }

--- a/src/main/java/com/dku/council/domain/danfesta/model/entity/LineUp.java
+++ b/src/main/java/com/dku/council/domain/danfesta/model/entity/LineUp.java
@@ -33,6 +33,7 @@ public class LineUp extends BaseEntity {
 
     private LocalDate performanceTime;
 
+    @Enumerated(EnumType.STRING)
     private FestivalDate festivalDate;
 
     private boolean isOpened;

--- a/src/main/java/com/dku/council/domain/danfesta/repository/LineUpRepository.java
+++ b/src/main/java/com/dku/council/domain/danfesta/repository/LineUpRepository.java
@@ -1,12 +1,18 @@
 package com.dku.council.domain.danfesta.repository;
 
+import com.dku.council.domain.danfesta.model.FestivalDate;
 import com.dku.council.domain.danfesta.model.entity.LineUp;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface LineUpRepository extends JpaRepository<LineUp, Long> {
 
     List<LineUp> findAll(Specification<LineUp> spec);
+
+    @Query("select l from LineUp  l where l.festivalDate =:festivalDate")
+    List<LineUp> findAllByFestivalDate(@Param("festivalDate") FestivalDate festivalDate);
 }

--- a/src/main/java/com/dku/council/domain/danfesta/service/LineUpService.java
+++ b/src/main/java/com/dku/council/domain/danfesta/service/LineUpService.java
@@ -106,14 +106,14 @@ public class LineUpService {
     }
 
     @Transactional
-    public void changeToTrue(Long userId) {
+    public void changeToTrue(Long userId, FestivalDate festivalDate) {
         User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
 
         if (!user.getId().equals(userId) || !user.getUserRole().isAdmin()) {
             throw new NotGrantedException();
         }
 
-        List<LineUp> list = lineUpRepository.findAll();
+        List<LineUp> list = lineUpRepository.findAllByFestivalDate(festivalDate);
         for(LineUp lineUp : list) {
             lineUp.changeIsOpened();
             lineUpRepository.save(lineUp);


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[ ] 기능 추가
-[ ] 기능 삭제
-[x] 버그 수정
-[ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 사항
1. 라인업 기능에서 공개 여부를 축제 일차에 맞는 것만 수정하도록 변경
