### PR TITLE
fix : 스탬프 정보를 조회할 때, 정보가 있으면 리턴 없으면 새로 생성한 후 리턴하게끔 수정

### DIFF
--- a/src/main/java/com/dku/council/domain/danfesta/controller/StampController.java
+++ b/src/main/java/com/dku/council/domain/danfesta/controller/StampController.java
@@ -20,33 +20,11 @@ public class StampController {
     private final StampService stampService;
 
     /**
-     * 기본 스탬프 정보 생성
-     * <p>부스별 미션을 수행하기 위한 사전단계로 제일 먼저 사용되어야 합니다.</p>
-     * <p>단, 처음 한번만 사용해야하기 때문에 이후에는 기본 스탬프 정보를 확인하는 API로 판별해야 합니다.</p>
-     */
-    @PostMapping
-    @UserAuth
-    public void createDefaultSpecialMission(AppAuthentication auth) {
-        stampService.createDefaultStampInfo(auth.getUserId());
-    }
-
-    /**
      * 현재 내가 받은 스탬프 조회
      */
     @PostMapping("/my")
     @UserAuth
     public ResponseStampInfoDto getMySpecialMission(AppAuthentication auth) {
         return stampService.getStampInfo(auth.getUserId());
-    }
-
-    /**
-     * 기본 스탬프 정보를 가지고 있는 확인
-     * <p>true일 경우가 스탬프 판이 존재하는 값입니다.</p>
-     */
-    @GetMapping
-    @UserAuth
-    public ResponseBooleanDto checkDefaultSpecialMission(AppAuthentication auth) {
-        boolean result = stampService.checkDefaultStampInfo(auth.getUserId());
-        return new ResponseBooleanDto(result);
     }
 }

--- a/src/main/java/com/dku/council/domain/danfesta/service/StampService.java
+++ b/src/main/java/com/dku/council/domain/danfesta/service/StampService.java
@@ -21,22 +21,19 @@ public class StampService {
     private final UserRepository userRepository;
 
     @Transactional
-    public void createDefaultStampInfo(Long userId) {
-        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
-
-        Stamp s = Stamp.builder()
-                .user(user)
-                .build();
-        stampRepository.save(s);
-    }
-
     public ResponseStampInfoDto getStampInfo(Long userId) {
-        Stamp s = stampRepository.findByUserId(userId).orElseThrow(StampNotFoundException::new);
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
+        Stamp s;
+
+        if(stampRepository.findByUserId(userId).isEmpty()) {
+            s = Stamp.builder()
+                    .user(user)
+                    .build();
+            s = stampRepository.save(s);
+        } else {
+            s = stampRepository.findByUserId(userId).orElseThrow(StampNotFoundException::new);
+        }
 
         return new ResponseStampInfoDto(s);
-    }
-
-    public boolean checkDefaultStampInfo(Long userId) {
-        return stampRepository.existsByUserId(userId);
     }
 }


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 사항
1. 스탬프 관련 기능 수정
   - 스탬프 존재 유무 boolean 메소드 삭제 및 기본 스탬프 생성 기능 삭제
   - 자신의 스탬프가 있을 시 리턴, 없을 시 새로 생성 후 리턴으로 수정